### PR TITLE
Enabled multi targeted nuget package build

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ Provides a way to test WebAPI projects.
 This project is a modified version of [Nancy.Testing][1] but built to work with ASP.Net WebAPI
 
   [1]: https://github.com/NancyFx/Nancy/tree/master/src/Nancy.Testing
+
+---
+
+To build nuget packages open a Developer Command Prompt and run the 
+
+>buildandpack.cmd
+
+command.

--- a/WebAPI.Testing.nuspec
+++ b/WebAPI.Testing.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>WebAPI.Testing</id>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
         <title>WebAPI.Testing</title>
         <authors>Jonathan Channon</authors>
         <owners>Jonathan Channon</owners>
@@ -17,7 +17,9 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="src\WebAPI.Testing\bin\Release\WebAPI.Testing.dll" target="lib\net40\WebAPI.Testing.dll" />
-        
+        <file src="src\WebAPI.Testing\bin\Release\net40\WebAPI.Testing.dll" target="lib\net40\WebAPI.Testing.dll" />
+        <file src="src\WebAPI.Testing\bin\Release\net40\WebAPI.Testing.pdb" target="lib\net40\WebAPI.Testing.pdb" />
+        <file src="src\WebAPI.Testing\bin\Release\net45\WebAPI.Testing.dll" target="lib\net45\WebAPI.Testing.dll" />
+        <file src="src\WebAPI.Testing\bin\Release\net45\WebAPI.Testing.pdb" target="lib\net45\WebAPI.Testing.pdb" />
     </files>
 </package>

--- a/WebAPI.Testing.sln
+++ b/WebAPI.Testing.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAPI.Testing", "src\WebAPI.Testing\WebAPI.Testing.csproj", "{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAPI.Testing.Tests", "src\WebAPI.Testing.Tests\WebAPI.Testing.Tests.csproj", "{D32E2000-3FDF-4D3E-A29A-03CB78D65944}"
@@ -10,25 +12,35 @@ Global
 		Debug|Any CPU = Debug|Any CPU
 		MonoDebug|Any CPU = MonoDebug|Any CPU
 		MonoRelease|Any CPU = MonoRelease|Any CPU
+		Release 4.0|Any CPU = Release 4.0|Any CPU
+		Release 4.5|Any CPU = Release 4.5|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.MonoDebug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.MonoDebug|Any CPU.Build.0 = Debug|Any CPU
-		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
-		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
-		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}.MonoDebug|Any CPU.ActiveCfg = MonoDebug|Any CPU
 		{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}.MonoDebug|Any CPU.Build.0 = MonoDebug|Any CPU
 		{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}.MonoRelease|Any CPU.ActiveCfg = MonoRelease|Any CPU
 		{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}.MonoRelease|Any CPU.Build.0 = MonoRelease|Any CPU
+		{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}.Release 4.0|Any CPU.ActiveCfg = Release 4.0|Any CPU
+		{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}.Release 4.0|Any CPU.Build.0 = Release 4.0|Any CPU
+		{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}.Release 4.5|Any CPU.ActiveCfg = Release 4.5|Any CPU
+		{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}.Release 4.5|Any CPU.Build.0 = Release 4.5|Any CPU
 		{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D79203C0-B672-4751-9C95-C3AB7D3FEFBE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.MonoDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.MonoDebug|Any CPU.Build.0 = Debug|Any CPU
+		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
+		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.Release 4.0|Any CPU.ActiveCfg = Release 4.0|Any CPU
+		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.Release 4.0|Any CPU.Build.0 = Release 4.0|Any CPU
+		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.Release 4.5|Any CPU.ActiveCfg = Release 4.5|Any CPU
+		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.Release 4.5|Any CPU.Build.0 = Release 4.5|Any CPU
+		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D32E2000-3FDF-4D3E-A29A-03CB78D65944}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/buildandpack.cmd
+++ b/buildandpack.cmd
@@ -1,0 +1,2 @@
+msbuild .\src\WebAPI.Testing\WebAPI.Testing.csproj /t:Build /p:Configuration="Release 4.5"
+msbuild .\src\WebAPI.Testing\WebAPI.Testing.csproj /t:Build;Package /p:Configuration="Release 4.0"

--- a/src/WebAPI.Testing.Tests/WebAPI.Testing.Tests.csproj
+++ b/src/WebAPI.Testing.Tests/WebAPI.Testing.Tests.csproj
@@ -34,6 +34,24 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release 4.5|AnyCPU'">
+    <OutputPath>bin\Release 4.5\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release 4.0|AnyCPU'">
+    <OutputPath>bin\Release 4.0\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core">
       <HintPath>..\..\packages\Castle.Core.3.1.0\lib\net40-client\Castle.Core.dll</HintPath>

--- a/src/WebAPI.Testing/Properties/AssemblyInfo.cs
+++ b/src/WebAPI.Testing/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WebAPI.Testing")]
+[assembly: AssemblyDescription("Allows full pipeline testing for ASP.Net Web API")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Jonathan Channon")]
+[assembly: AssemblyProduct("WebAPI.Testing")]
+[assembly: AssemblyCopyright("Copyright ©  2012")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("564ca92f-74bd-4e1a-b7df-7059a38ca0b0")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/src/WebAPI.Testing/WebAPI.Testing.csproj
+++ b/src/WebAPI.Testing/WebAPI.Testing.csproj
@@ -89,6 +89,26 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release 4.5|AnyCPU'">
+    <OutputPath>bin\Release\net45\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release 4.0|AnyCPU'">
+    <OutputPath>bin\Release\net40\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="CsQuery">
       <HintPath>..\..\packages\CsQuery.1.3.1\lib\net40\CsQuery.dll</HintPath>
@@ -116,7 +136,7 @@
     <Reference Include="System.Web.Http" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Browser.cs" />
     <Compile Include="BrowserContext.cs" />
     <Compile Include="BrowserContextExtensions.cs" />
@@ -150,9 +170,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -161,4 +179,18 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="AfterBuild">
+    <!-- Load up the information from the assembly -->
+    <GetAssemblyIdentity AssemblyFiles="$(OutputPath)$(AssemblyName).dll">
+      <Output TaskParameter="Assemblies" ItemName="OutputAssemblyInfo" />
+    </GetAssemblyIdentity>
+    <Message Text="Info: %(OutputAssemblyInfo.Version)" />
+  </Target>
+  <Target Name="Package">
+    <!-- Ensure the Package directory exists for this project -->
+    <RemoveDir Directories="..\..\NuGet" />
+    <MakeDir Directories="..\..\NuGet" />
+    <!-- Package the project -->
+    <Exec WorkingDirectory="..\..\$(BuildDir)" Command="NuGet.exe pack WebAPI.Testing.nuspec -Verbosity detailed -OutputDir &quot;NuGet&quot; -Version %(OutputAssemblyInfo.Version) -Properties &quot;Configuration=$(Configuration)&quot;" />
+  </Target>
 </Project>


### PR DESCRIPTION
I needed to be able to target .net 4.0. I've added scripts to generate a multi targeted nuget package. Would you be able to upload this to nuget soon? 

I did notice that the existing nuget package indicates that the assembly is a net40 assembly while it actually targets net45.